### PR TITLE
Added additional flexibility to match spec

### DIFF
--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -8,26 +8,177 @@
 
 use serde;
 use serde_json;
+use serde::de::Visitor;
 
 pub type Ext = serde_json::map::Map<String, serde_json::value::Value>;
 
+struct BoolVisitor;
+
+impl<'de> Visitor<'de> for BoolVisitor {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a bool value or integer 0 or 1")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        match value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(E::custom(format!("a bool value must be 0 or 1: {}", value))),
+        }
+    }
+
+    fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        match value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(E::custom(format!("a bool value must be 0 or 1: {}", value))),
+        }
+    }
+
+    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        match value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(E::custom(format!("a bool value must be 0 or 1: {}", value))),
+        }
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        match value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(E::custom(format!("a bool value must be 0 or 1: {}", value))),
+        }
+    }
+}
+
+struct StringVisitor;
+
+impl<'de> Visitor<'de> for StringVisitor {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a bool value or integer 0 or 1")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_i32<E>(self, value: i32) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_char<E>(self, value: char) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value.to_string())
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        Ok(value)
+    }
+}
+
 pub fn bool_to_u8<S>(x: &bool, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
+    where
+        S: serde::Serializer,
 {
     serializer.serialize_u8(*x as u8)
 }
 
 pub fn u8_to_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
 {
-    match serde::Deserialize::deserialize(deserializer) {
-        Ok(0) => Ok(false),
-        Ok(1) => Ok(true),
-        Ok(_) => Err(serde::de::Error::custom("The number is neither 1 nor 0")),
-        Err(e) => Err(e),
-    }
+    deserializer.deserialize_any(BoolVisitor)
 }
 
 pub fn default_false() -> bool {
@@ -39,8 +190,8 @@ pub fn is_false(x: &bool) -> bool {
 }
 
 pub fn mbool_to_u8<S>(mx: &Option<bool>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
+    where
+        S: serde::Serializer,
 {
     match mx {
         None => serializer.serialize_none(),
@@ -49,13 +200,26 @@ where
 }
 
 pub fn u8_to_mbool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
-where
-    D: serde::Deserializer<'de>,
+    where
+        D: serde::Deserializer<'de>,
 {
-    match serde::Deserialize::deserialize(deserializer) {
-        Ok(0) => Ok(Some(false)),
-        Ok(1) => Ok(Some(true)),
-        Ok(_) => Ok(None),
-        Err(e) => Err(e),
+    match deserializer.deserialize_any(BoolVisitor) {
+        Ok(value) => Ok(Some(value)),
+        Err(_) => Ok(None),
     }
+}
+
+pub fn is_none_or_empty<T>(vec: &Option<Vec<T>>) -> bool {
+    if let Some(vec) = vec {
+        vec.is_empty()
+    } else {
+        true
+    }
+}
+
+pub fn anything_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_any(StringVisitor)
 }

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -22,15 +22,15 @@ impl<'de> Visitor<'de> for BoolVisitor {
     }
 
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value)
     }
 
     fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         match value {
             0 => Ok(false),
@@ -40,8 +40,8 @@ impl<'de> Visitor<'de> for BoolVisitor {
     }
 
     fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         match value {
             0 => Ok(false),
@@ -51,8 +51,8 @@ impl<'de> Visitor<'de> for BoolVisitor {
     }
 
     fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         match value {
             0 => Ok(false),
@@ -62,8 +62,8 @@ impl<'de> Visitor<'de> for BoolVisitor {
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         match value {
             0 => Ok(false),
@@ -83,100 +83,100 @@ impl<'de> Visitor<'de> for StringVisitor {
     }
 
     fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_i8<E>(self, value: i8) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_i16<E>(self, value: i16) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_i32<E>(self, value: i32) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_char<E>(self, value: char) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value.to_string())
     }
 
     fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
+    where
+        E: serde::de::Error,
     {
         Ok(value)
     }
 }
 
 pub fn bool_to_u8<S>(x: &bool, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
+where
+    S: serde::Serializer,
 {
     serializer.serialize_u8(*x as u8)
 }
 
 pub fn u8_to_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
-    where
-        D: serde::Deserializer<'de>,
+where
+    D: serde::Deserializer<'de>,
 {
     deserializer.deserialize_any(BoolVisitor)
 }
@@ -190,8 +190,8 @@ pub fn is_false(x: &bool) -> bool {
 }
 
 pub fn mbool_to_u8<S>(mx: &Option<bool>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
+where
+    S: serde::Serializer,
 {
     match mx {
         None => serializer.serialize_none(),
@@ -200,8 +200,8 @@ pub fn mbool_to_u8<S>(mx: &Option<bool>, serializer: S) -> Result<S::Ok, S::Erro
 }
 
 pub fn u8_to_mbool<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
-    where
-        D: serde::Deserializer<'de>,
+where
+    D: serde::Deserializer<'de>,
 {
     match deserializer.deserialize_any(BoolVisitor) {
         Ok(value) => Ok(Some(value)),
@@ -218,8 +218,8 @@ pub fn is_none_or_empty<T>(vec: &Option<Vec<T>>) -> bool {
 }
 
 pub fn anything_to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
-    where
-        D: serde::Deserializer<'de>,
+where
+    D: serde::Deserializer<'de>,
 {
     deserializer.deserialize_any(StringVisitor)
 }

--- a/src/v2_5/bid.rs
+++ b/src/v2_5/bid.rs
@@ -3,8 +3,9 @@ use serde_utils;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Bid {
+    #[serde(deserialize_with = "serde_utils::anything_to_string")]
     pub id: String,
-    #[serde(rename = "impid")]
+    #[serde(rename = "impid", deserialize_with = "serde_utils::anything_to_string")]
     pub imp_id: String,
     pub price: f64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v2_5/bid_request.rs
+++ b/src/v2_5/bid_request.rs
@@ -87,7 +87,8 @@ pub struct BidRequest {
     // Maximum time in milliseconds the exchange allows for bids to
     // be received including Internet latency to avoid timeout. This
     // value supersedes any a priori guidance from the exchange.
-    pub tmax: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tmax: Option<u64>,
 
     // White list of buyer seats (e.g., advertisers, agencies) allowed
     // to bid on this impression. IDs of seats and knowledge of the
@@ -176,7 +177,7 @@ impl BidRequest {
             user: None,
             test: false,
             auction_type: AuctionType::FirstPrice,
-            tmax: 0,
+            tmax: Some(0),
             seat_whitelist: vec![],
             seat_blocklist: vec![],
             all_imps: false,

--- a/src/v2_5/bid_request.rs
+++ b/src/v2_5/bid_request.rs
@@ -177,7 +177,7 @@ impl BidRequest {
             user: None,
             test: false,
             auction_type: AuctionType::FirstPrice,
-            tmax: Some(0),
+            tmax: None,
             seat_whitelist: vec![],
             seat_blocklist: vec![],
             all_imps: false,
@@ -240,7 +240,7 @@ mod tests {
             user: None,
             test: false,
             auction_type: AuctionType::FirstPrice,
-            tmax: 0,
+            tmax: None,
             seat_whitelist: vec![],
             seat_blocklist: vec![],
             all_imps: false,
@@ -254,7 +254,7 @@ mod tests {
             ext: None,
         };
 
-        let expected = r#"{"id":"1234","imp":[],"at":1,"tmax":0}"#;
+        let expected = r#"{"id":"1234","imp":[],"at":1}"#;
         let serialized = serde_json::to_string(&b).unwrap();
 
         assert_eq!(expected, serialized)
@@ -265,8 +265,7 @@ mod tests {
         let serialized = r#"{
             "id": "1234",
             "imp": [],
-            "at": 2,
-            "tmax": 0
+            "at": 2
         }"#;
 
         let res = serde_json::from_str(serialized);
@@ -285,7 +284,7 @@ mod tests {
             user: None,
             test: false,
             auction_type: AuctionType::SecondPricePlus,
-            tmax: 0,
+            tmax: None,
             seat_whitelist: vec![],
             seat_blocklist: vec![],
             all_imps: false,

--- a/src/v2_5/device.rs
+++ b/src/v2_5/device.rs
@@ -15,7 +15,12 @@ pub struct Device {
     pub ua: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub geo: Option<Geo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serde_utils::mbool_to_u8",
+        deserialize_with = "serde_utils::u8_to_mbool"
+    )]
     pub dnt: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lmt: Option<bool>,

--- a/src/v2_5/user.rs
+++ b/src/v2_5/user.rs
@@ -15,8 +15,8 @@ pub struct User {
     #[serde(rename = "buyeruid", skip_serializing_if = "Option::is_none")]
     pub buyer_uid: Option<String>,
     // This object used by publishers to pass additional attributes about the user or content.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub data: Vec<Data>,
+    #[serde(skip_serializing_if = "serde_utils::is_none_or_empty")]
+    pub data: Option<Vec<Data>>,
     // The User Ext Object, which is used to indicate requests that contain certain user identifiers and are subject to GDPR regulations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ext: Option<serde_utils::Ext>,

--- a/src/v2_5/video.rs
+++ b/src/v2_5/video.rs
@@ -71,8 +71,13 @@ pub struct Video {
     pub maxbitrate: Option<u32>,
     /// Indicates if letter-boxing of 4:3 content into
     /// a 16:9 window is allowed, where 0 = no, 1 = yes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub boxingallowed: Option<u32>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serde_utils::mbool_to_u8",
+        deserialize_with = "serde_utils::u8_to_mbool"
+    )]
+    pub boxingallowed: Option<bool>,
     /// Playback methods that may be in use.
     /// If none are specified, any method may be used.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
Now capable of parsing all examples at https://github.com/openrtb/examples after they have been made valid json. I had to add commas and remove trailing commas to make them valid.

The spec: https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf

- `BidRequest::tmax` is now optional.
- `User::data` is now optional.
- `Video::boxingallowed` is now a bool that can be parsed from u8 or bool.
- `Device::dnt` now supports parsing from bool or u8.
- `Bid::id` and `Bid::imp_id` can now be an integer when deserializing.

The big parts of this change were expanding flexibility of `u8_to_bool` and `u8_to_mbool` so that they can parse from `true`, `false`, `0`, or `1`.

The other odd one is adding `anything_to_string` that will take any valid json value and convert it to a `String` to support `id`s that may come in as integers from incorrect json.

See #3, this may help.